### PR TITLE
Support HTML in textField.

### DIFF
--- a/scripts/droppable.js
+++ b/scripts/droppable.js
@@ -66,6 +66,14 @@ H5P.TextDroppable = (function ($) {
     this.$dropzoneContainer.appendTo($container);
   };
   /**
+   * Inserts the droppable after the provided element.
+   * @public
+   * @param {jQuery} $element Element after which the dropzone will be inserted.
+   */
+  Droppable.prototype.insertDroppableAfter = function ($element) {
+    this.$dropzoneContainer.insertAfter($element);
+  };
+  /**
    * Appends the draggable contained within this dropzone to the argument.
    * @public
    * @param {jQuery} $container Container which the draggable will append to.

--- a/semantics.json
+++ b/semantics.json
@@ -25,9 +25,21 @@
     "importance": "high",
     "name": "textField",
     "type": "text",
-    "widget": "textarea",
+    "widget": "html",
     "placeholder": "*Oslo* is the capital of Norway, *Stockholm* is the capital of Sweden and *Copenhagen* is the capital of Denmark. All cities are located in the *Scandinavian:Northern Part of Europe* peninsula.",
-    "description": "Droppable words are added with an asterisk (*) in front and behind the correct word/phrase. You may add a textual tip, using a colon (:) in front of the tip. Example: H5P content may be edited using a *browser:Something you use every day*.<br>For every empty spot there is only one correct word."
+    "description": "Droppable words are added with an asterisk (*) in front and behind the correct word/phrase. You may add a textual tip, using a colon (:) in front of the tip. Example: H5P content may be edited using a *browser:Something you use every day*.<br>For every empty spot there is only one correct word.<br><strong>Be careful to not apply formatting or styling to text within a droppable word/phrase.</strong>",
+    "enterMode": "p",
+    "tags": [
+      "strong",
+      "em",
+      "u",
+      "a",
+      "ul",
+      "ol",
+      "h2",
+      "h3",
+      "hr"
+    ]
   },
   {
     "label": "Text for \"Check\" button",


### PR DESCRIPTION
We needed to be able to support HTML in the text. This change implements it. HTML styling/formatting (tags) **inside** a droppable word/phrase will prevent that droppable from working, so a warning is added to this effect in the textField description. For example this will work:
`<p><b>The *cat* sat on the <i>*mat*</i></b></p>`
But this won't:
`<p><b>The *cat* sat on the *<i>mat</i>*</b></p>`
This is because the DOM elements in the (HTML) textField are processed recursively, and text nodes containing asterisks are processed individually (and then broken up into new text nodes and droppable elements as necessary).