### PR TITLE
No wide screen mode

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/af.json
+++ b/language/af.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/ar.json
+++ b/language/ar.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "تلميح"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/bg.json
+++ b/language/bg.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Незабавна обратна връзка"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/bs.json
+++ b/language/bs.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instantna povratna informacija"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/ca.json
+++ b/language/ca.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/cs.json
+++ b/language/cs.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/da.json
+++ b/language/da.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/de.json
+++ b/language/de.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Sofortige Rückmeldung"
+        },
+        {
+          "label": "Lösungen unterhalb des Inhalts",
+          "description": "Wenn gesetzt, werden Lösungstexte immer unterhalb des Inhalts angezeigt."
         }
       ]
     },

--- a/language/el.json
+++ b/language/el.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Άμεση ανατροφοδότηση"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/es.json
+++ b/language/es.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Retroalimentacion instantanea"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/et.json
+++ b/language/et.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Kohene tagasiside"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/eu.json
+++ b/language/eu.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Berehalako feedbacka"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/fi.json
+++ b/language/fi.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Pikapalaute"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/fr.json
+++ b/language/fr.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Correction instantanée"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/he.json
+++ b/language/he.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/hu.json
+++ b/language/hu.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/it.json
+++ b/language/it.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Feedback istantaneo"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/ja.json
+++ b/language/ja.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "即時フィードバック"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/ko.json
+++ b/language/ko.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/nb.json
+++ b/language/nb.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/nl.json
+++ b/language/nl.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Geef direct feedback (Antwoorden)"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/nn.json
+++ b/language/nn.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/pl.json
+++ b/language/pl.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Natychmiastowy komentarz"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Feedback instantâneo"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/pt.json
+++ b/language/pt.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Feedback instantâneo"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/ro.json
+++ b/language/ro.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/ru.json
+++ b/language/ru.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Мгновенная обратная связь"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/sl.json
+++ b/language/sl.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Sprotno preverjaj odgovore"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/sma.json
+++ b/language/sma.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/sme.json
+++ b/language/sme.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/smj.json
+++ b/language/smj.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/sr.json
+++ b/language/sr.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/sv.json
+++ b/language/sv.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Omedelbar feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/tr.json
+++ b/language/tr.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/uk.json
+++ b/language/uk.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Миттєвий зворотній зв'язок"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/vi.json
+++ b/language/vi.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "Instant feedback"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/language/zh-tw.json
+++ b/language/zh-tw.json
@@ -125,6 +125,10 @@
         },
         {
           "label": "即時回饋"
+        },
+        {
+          "label": "Solutions below content",
+          "description": "If set, will force solution texts to be displayed below the content."
         }
       ]
     },

--- a/library.json
+++ b/library.json
@@ -2,8 +2,8 @@
   "title": "Drag Text",
   "description": "Drag and drop pieces of text to create complete sentences.",
   "majorVersion": 1,
-  "minorVersion": 8,
-  "patchVersion": 7,
+  "minorVersion": 9,
+  "patchVersion": 0,
   "coreApi": {
     "majorVersion": 1,
     "minorVersion": 19

--- a/semantics.json
+++ b/semantics.json
@@ -264,6 +264,15 @@
         "type": "boolean",
         "default": false,
         "optional": true
+      },
+      {
+        "name": "noWideScreenLayout",
+        "label": "Solutions below content",
+        "description": "If set, will force solution texts to be displayed below the content.",
+        "importance": "low",
+        "type": "boolean",
+        "default": false,
+        "optional": true
       }
     ]
   },

--- a/src/scripts/drag-text.js
+++ b/src/scripts/drag-text.js
@@ -51,7 +51,7 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
   var WORDS_CONTAINER = "h5p-drag-droppable-words";
   var DROPZONE_CONTAINER = "h5p-drag-dropzone-container";
   var DRAGGABLES_CONTAINER = "h5p-drag-draggables-container";
-  
+
   //Special Sub-containers:
   var DRAGGABLES_WIDE_SCREEN = 'h5p-drag-wide-screen';
   var DRAGGABLE_ELEMENT_WIDE_SCREEN = 'h5p-drag-draggable-wide-screen';
@@ -85,7 +85,8 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
         enableRetry: true,
         enableSolutionsButton: true,
         enableCheckButton: true,
-        instantFeedback: false
+        instantFeedback: false,
+        noWideScreenLayout: false
       },
       showSolution : "Show solution",
       dropZoneIndex: "Drop Zone @index.",
@@ -365,7 +366,7 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
     self.addDropzoneWidth();
 
     //Find ratio of width to em, and make sure it is less than the predefined ratio, make sure widest draggable is less than a third of parent width.
-    if ((self.$inner.width() / parseFloat(self.$inner.css("font-size"), 10) > 43) && (self.widestDraggable <= (self.$inner.width() / 3))) {
+    if (!self.params.behaviour.noWideScreenLayout && (self.$inner.width() / parseFloat(self.$inner.css("font-size"), 10) > 43) && (self.widestDraggable <= (self.$inner.width() / 3))) {
       // Adds a class that floats the draggables to the right.
       self.$draggables.addClass(DRAGGABLES_WIDE_SCREEN);
 

--- a/upgrades.js
+++ b/upgrades.js
@@ -54,6 +54,14 @@ H5PUpgrades['H5P.DragText'] = (function ($) {
         }
 
         finished(null, parameters, extras);
+      },
+
+      9: function (parameters, finished, extras) {
+        if (parameters && parameters.behaviour) {
+          parameters.behaviour.noWideScreenLayout = false;
+        }
+
+        finished(null, parameters, extras);
       }
     }
   };


### PR DESCRIPTION
If merged in, this content type will cover the user story:
"As a teacher, I can force the solution texts to always be displayed below the content, not only in wide-screen-mode."

Was requested in https://h5p.org/node/262265 for instance