### PR TITLE
Improve draggable sizing

### DIFF
--- a/src/scripts/drag-text.js
+++ b/src/scripts/drag-text.js
@@ -412,7 +412,7 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
    * @return {object} Maximum sizes from draggables.
    */
   DragText.prototype.getMaxDraggableSizes = function (initial = {width: 0, height: 0}) {
-    const measurableDraggables = this.draggables.filter(function (draggable) {
+    const undoneDraggables = this.draggables.filter(function (draggable) {
       // Ignore draggables that have been dropped
       return !draggable.getDraggableElement().hasClass('h5p-drag-dropped');
     });
@@ -421,17 +421,26 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
     const currentFontSize = parseInt(this.$inner.css('font-size'), 10);
     if (this.fontSize !== currentFontSize) {
       this.fontSize = currentFontSize;
-      if (measurableDraggables.length > 0) {
+      if (undoneDraggables.length > 0) {
         initial = {width: 0, height: 0};
       }
     }
 
-    // Get highest values for height and width
-    return measurableDraggables
+    initial = undoneDraggables
       .reduce(function (maxSizes, draggable) {
         const element = draggable.getDraggableElement();
         return {
           width: Math.max(maxSizes.width, element.width()),
+          height: initial.height
+        };
+      }, initial);
+
+    // Get highest values for height and width
+    return this.draggables
+      .reduce(function (maxSizes, draggable) {
+        const element = draggable.getDraggableElement();
+        return {
+          width: initial.width,
           height: Math.max(maxSizes.height, element.height())
         };
       }, initial);

--- a/src/scripts/drag-text.js
+++ b/src/scripts/drag-text.js
@@ -748,7 +748,13 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
       .forEach(function(part) {
         if(self.isAnswerPart(part)) {
           // is draggable/droppable
-          const solution = lex(part);
+          const solution = lex(part)
+
+          // Only inline LaTeX allowed
+          solution.text = solution.text
+            .replace(/\\\[(.*?)\\\]/g, '\\\($1\\\)')
+            .replace(/\$\$(.*?)\$\$/g, '\\\($1\\\)');
+
           const draggable = self.createDraggable(solution.text);
           const droppable = self.createDroppable(solution.text, solution.tip, solution.correctFeedback, solution.incorrectFeedback);
 
@@ -1496,16 +1502,16 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
 /**
  * Static helper method to enable parsing of question text into a format useful
  * for generating reports.
- * 
+ *
  * PS: The leading backslash for the correct and incorrect feedback within
  * answer parts must be escaped appropriately:
- * 
+ *
  * Example:
- * 
+ *
  * question: 'H5P content is *interactive\\+Correct! \\-Incorrect, try again!*.'
- * 
+ *
  * produces the following:
- * 
+ *
  * [
  *   {
  *     type: 'text',
@@ -1513,14 +1519,14 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
  *   },
  *   {
  *     type: 'answer',
- *     correct: 'interactive'  
+ *     correct: 'interactive'
  *   },
  *   {
  *     type: 'text',
  *     content: '.'
  *   }
  * ]
- * 
+ *
  * @param {string} question Question text for an H5P.DragText content item
  */
 H5P.DragText.parseText = function (question) {

--- a/src/scripts/draggable.js
+++ b/src/scripts/draggable.js
@@ -20,11 +20,11 @@ H5P.TextDraggable = (function ($) {
     self.initialIndex = index;
 
     // Shortening LaTeX would destroy it
-    const containsLatex = /\\\(.*?\\\)/.test(self.text);
+    this.containsLatex = /\\\(.*?\\\)/.test(self.text);
 
     self.shortFormat = self.text;
     //Shortens the draggable string if inside a dropbox.
-    if (!containsLatex && self.shortFormat.length > 20) {
+    if (!this.containsLatex && self.shortFormat.length > 20) {
       self.shortFormat = self.shortFormat.slice(0, 17) + '...';
     }
   }
@@ -200,6 +200,10 @@ H5P.TextDraggable = (function ($) {
    * Sets short format of draggable when inside a dropbox.
    */
   Draggable.prototype.setShortFormat = function () {
+    if (this.containsLatex) {
+      return; // Prevent unnecessary re-rerendering
+    }
+
     this.$draggable.html(this.shortFormat);
   };
 
@@ -216,6 +220,10 @@ H5P.TextDraggable = (function ($) {
    * Removes the short format of draggable when it is outside a dropbox.
    */
   Draggable.prototype.removeShortFormat = function () {
+    if (this.containsLatex) {
+      return; // Prevent unnecessary re-rerendering
+    }
+
     this.$draggable.html(this.text);
   };
 

--- a/src/scripts/draggable.js
+++ b/src/scripts/draggable.js
@@ -19,9 +19,12 @@ H5P.TextDraggable = (function ($) {
     self.index = index;
     self.initialIndex = index;
 
+    // Shortening LaTeX would destroy it
+    const containsLatex = /\\\(.*?\\\)/.test(self.text);
+
     self.shortFormat = self.text;
     //Shortens the draggable string if inside a dropbox.
-    if (self.shortFormat.length > 20) {
+    if (!containsLatex && self.shortFormat.length > 20) {
       self.shortFormat = self.shortFormat.slice(0, 17) + '...';
     }
   }

--- a/src/scripts/droppable.js
+++ b/src/scripts/droppable.js
@@ -78,15 +78,35 @@ H5P.TextDroppable = (function ($) {
   /**
    * Displays the solution next to the drop box if it is not correct.
    */
-  Droppable.prototype.showSolution = function () {
+  Droppable.prototype.showSolution = function (correctDraggable) {
+    // Reset fixed width
+    this.$showSolution.css('width', '');
+
     const correct = (this.containedDraggable !== null) && (this.containedDraggable.getAnswerText() === this.text);
     if (!correct) {
-      this.$showSolution.html(this.text);
+      if (correctDraggable.containsLatex) {
+        /*
+         * Use LaTeX already rendered for Draggable. MathJax still re-renders,
+         * but way quicker than if adding LaTaX as text. Should probably be tackled
+         * in MathDisplay?
+         * https://github.com/h5p/h5p-math-display/blob/5c2e312822c71f6d8bd33d3260f3ea92b697942e/scripts/mathdisplay.js#L232-L234
+         */
+        this.$showSolution.html(correctDraggable.getDraggableElement().first().html());
+        this.$showSolution.addClass('h5p-drag-text-latex');
+      }
+      else {
+        this.$showSolution.html(this.text);
+      }
     }
 
     this.$showSolution.prepend(correct ? this.$correctText : this.$incorrectText);
     this.$showSolution.toggleClass('incorrect', !correct);
     this.$showSolution.show();
+
+    // Workaround for MathJax re-rendering, avoid reflowing of text, still flickers
+    this.$showSolution.css({
+       width: this.$showSolution.width()
+    });
   };
 
   /**

--- a/src/styles/drag-text.css
+++ b/src/styles/drag-text.css
@@ -160,7 +160,6 @@
 .h5p-drag-text .h5p-drag-dropped.h5p-drag-draggable-correct {
   padding: 0;
   color: #255c41;
-  border: none;
   box-shadow: none;
   line-height: 1.5;
   background: none;
@@ -168,17 +167,31 @@
 
 .h5p-drag-text .h5p-drag-dropped.h5p-drag-draggable-wrong {
   padding: 0;
-  border: none;
   color: #b71c1c;
   box-shadow: none;
   line-height: 1.5;
   background: none;
 }
 
+.h5p-drag-text .h5p-drag-droppable-words:not(.h5p-drag-text-has-latex) .h5p-drag-dropped.h5p-drag-draggable-correct,
+.h5p-drag-text .h5p-drag-droppable-words:not(.h5p-drag-text-has-latex) .h5p-drag-dropped.h5p-drag-draggable-wrong {
+  border: none;
+}
+
+.h5p-drag-text .h5p-drag-droppable-words.h5p-drag-text-has-latex .h5p-drag-dropped.h5p-drag-draggable-correct,
+.h5p-drag-text .h5p-drag-droppable-words.h5p-drag-text-has-latex .h5p-drag-dropped.h5p-drag-draggable-wrong {
+  border-color: transparent;
+}
+
 /* Show solution container */
 .h5p-drag-text .h5p-drag-show-solution-container {
   position: relative;
-  display: inline;
+  display: inline-flex;
+  flex-direction: column;
+  height: 1.25em;
+  justify-content: center;
+  vertical-align: middle;
+  top: -0.1em;
 }
 
 .h5p-drag-text .h5p-drag-show-solution-container.incorrect {
@@ -189,6 +202,10 @@
   padding: 0.15em;
   border-radius: 0.25em;
   margin-left: 0.5em;
+}
+
+.h5p-drag-text .h5p-drag-show-solution-container.h5p-drag-text-latex > span {
+  padding-top: 0.5em;
 }
 
 .h5p-drag-text .h5p-drag-droppable-words {
@@ -211,8 +228,17 @@
   padding-top: 0;
 }
 
-.h5p-drag-text .h5p-drag-draggable-wide-screen {
-  display: block;
+.h5p-drag-text .h5p-drag-draggable {
+  flex-direction: column;
+  justify-content: center;
+}
+
+.h5p-drag-text .h5p-drag-draggable:not(.wide-screen) {
+  display: inline-flex;
+}
+
+.h5p-drag-text .h5p-drag-draggable.wide-screen {
+  display: flex;
 }
 
 .h5p-drag-text [aria-dropeffect].ui-droppable.ui-droppable-disabled.ui-state-disabled{


### PR DESCRIPTION
When merged in, this pull request will take care of 
* https://h5ptechnology.atlassian.net/browse/HFP-3041 (LaTex being destroyed when text gets shortened on drop)
* https://h5ptechnology.atlassian.net/browse/HFP-2919
  * same as HFP-3041
  * keep proper size when entering/exiting fullScreen mode in Course Presentation
  * infinite loop in MathDisplay already fixed in https://github.com/h5p/h5p-math-display/commit/8fe2a3540c78e4af330d2633602bc8933f9b564c