### PR TITLE
Add margin if dropzone container has tip

### DIFF
--- a/src/scripts/droppable.js
+++ b/src/scripts/droppable.js
@@ -42,6 +42,7 @@ H5P.TextDroppable = (function ($) {
         tipLabel: self.params.tipLabel,
         tabcontrol: true
       });
+      self.$dropzoneContainer.addClass('has-tip');
       self.$dropzoneContainer.append(self.$tip);
 
       // toggle tabindex on tip, based on dropzone focus

--- a/src/styles/drag-text.css
+++ b/src/styles/drag-text.css
@@ -75,6 +75,9 @@
   display: inline;
   padding-right: 0.1em;
 }
+.h5p-drag-text .h5p-drag-dropzone-container.has-tip {
+  margin-right: 0.25em;
+}
 .h5p-drag-text [aria-dropeffect] {
   position:relative;
   top: -0.1em;


### PR DESCRIPTION
Curently, when a dropzone contains a hint/tip, then the _i_ symbol partially covers the first letter of whatever text comes afterwards.

If this pull request is merged in, then dropzone containers that contain a tip/hint will get some extra margin, so the _i_ symbol does not cover text anymore.