### PR TITLE
Revert "JI-3184 Fix intersection of draggable and droppable element"

### DIFF
--- a/src/scripts/drag-text.js
+++ b/src/scripts/drag-text.js
@@ -941,7 +941,7 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
       'tabindex': '-1'
     }).appendTo($dropzoneContainer)
       .droppable({
-        tolerance: 'intersect',
+        tolerance: 'pointer',
         drop: function (event, ui) {
           var draggable = self.getDraggableByElement(ui.draggable[0]);
           var droppable = self.getDroppableByElement(event.target);


### PR DESCRIPTION
Reverts h5p/h5p-drag-text#114

Current solution won't work for draggables >2*size of the drop zone. Switching back to pointer after conferring with PO.  