### PR TITLE
JI-3673 Fix npm script for 'watch'

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "ava",
     "dev": "cross-env NODE_ENV='development' webpack",
     "build": "cross-env NODE_ENV='production' webpack",
-    "watch": "webpack --watch"
+    "watch": "cross-env NODE_ENV='development' webpack --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
While updating the build chain as part of JI-3673, the npm script for `watch` was not updated and will fail, because the webpack configuration expects `process.env.NODE_ENV` to be set.

When merged in, `process.env.NODE_ENV` will be set for the `watch` script.