### PR TITLE
HFP-3656 Exclude package-lock.json from h5p library

### DIFF
--- a/.h5pignore
+++ b/.h5pignore
@@ -12,4 +12,5 @@ webpack.dev.config.js
 README.md
 CONTRIBUTING.md
 package.json
+package-lock.json
 crowdin.yml


### PR DESCRIPTION
Currently when using the H5P CLI tool for packing the library, it will put the (quite large) `package-lock.json` file into the library.

When merged in, fixed by adding `package-lock.json` to `.h5pignore`.