### PR TITLE
HFP-3658 Improve a11y focus on "Check" and "Show Solutions"

### DIFF
--- a/src/scripts/drag-text.js
+++ b/src/scripts/drag-text.js
@@ -1378,6 +1378,10 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
         }
       }
     }
+
+    // Allow to tab to filled drop zones.
+    this.addAllDroppablesToControls();
+    this.removeControlsFromEmptyDropZones();
   };
 
   /**

--- a/src/scripts/drag-text.js
+++ b/src/scripts/drag-text.js
@@ -299,7 +299,7 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
     const hasChildren = (dropZone.childNodes.length > 0);
 
     if (dropZone) {
-      let ariaLabel;
+      let ariaMessage;
 
       if (checkButtonPressed) {
         const droppable = this.getDroppableByElement(dropZone);
@@ -310,7 +310,7 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
         else {
           resultString = droppable.incorrectFeedback ? droppable.incorrectFeedback : this.params.incorrectText;
         }
-        ariaLabel = `${this.params.contains.replace('@index', index.toString()).replace('@draggable', text)} ${resultString}.`;
+        ariaMessage = `${this.params.contains.replace('@index', index.toString()).replace('@draggable', text)} ${resultString}.`;
 
         if (droppable && droppable.containedDraggable) {
           droppable.containedDraggable.updateAriaDescription(
@@ -319,13 +319,13 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
         }
       }
       else if (hasChildren) {
-        ariaLabel = `${this.params.contains.replace('@index', index.toString()).replace('@draggable', text)}`;
+        ariaMessage = `${this.params.contains.replace('@index', index.toString()).replace('@draggable', text)}`;
       }
       else {
-        ariaLabel = `${this.params.empty.replace('@index', index.toString())}`;
+        ariaMessage = `${this.params.empty.replace('@index', index.toString())}`;
       }
 
-      dropZone.setAttribute('aria-label', ariaLabel);
+      dropZone.setAttribute('aria-label', `${indexText} ${ariaMessage}`);
     }
   };
 

--- a/src/scripts/drag-text.js
+++ b/src/scripts/drag-text.js
@@ -499,7 +499,13 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
       });
       self.draggables.forEach(draggable => self.setDraggableAriaLabel(draggable));
       self.disableDraggables();
+
+      // Weird to remove and add, but that will ensure tabindex to be correct
       self.removeAllDroppablesFromControls();
+      self.addAllDroppablesToControls();
+
+      self.droppables[0].getElement().focus();
+
       self.hideButton('show-solution');
     }, self.initShowShowSolutionButton || false, {
       'aria-label': self.params.a11yShowSolution,
@@ -512,6 +518,7 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
         // move draggables to original container
         self.resetDraggables();
       }
+      self.resetDroppables();
       self.answered = false;
 
       self.hideEvaluation();
@@ -1309,6 +1316,8 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
     self.answered = false;
     //Reset draggables parameters and position
     self.resetDraggables();
+    self.resetDroppables();
+
     //Hides solution text and re-enable draggables
     self.hideEvaluation();
     self.hideExplanation();
@@ -1328,6 +1337,22 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
    * Resets the position of all draggables shuffled.
    */
   DragText.prototype.resetDraggables = function () {
+    Util.shuffle(this.draggables).forEach(this.revert, this);
+  };
+
+  /**
+   * Reset dropzones.
+   */
+  DragText.prototype.resetDroppables = function () {
+    const self = this;
+
+    this.droppables.forEach((droppable, index) => {
+      droppable.$dropzone.attr(
+        'aria-label',
+        self.params.dropZoneIndex.replace('@index', (index + 1).toString()) +
+          ' ' + self.params.empty.replace('@index', (index + 1).toString()),
+      )
+    })
     Util.shuffle(this.draggables).forEach(this.revert, this);
   };
 

--- a/src/scripts/drag-text.js
+++ b/src/scripts/drag-text.js
@@ -476,11 +476,7 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
           self.hideButton('check-answer');
         }
 
-        /*
-         * Allow all dropzones incl. empty ones to be accessed.
-         * Weird to remove and add, but that will ensure tabindex to be correct.
-         */
-        self.removeAllDroppablesFromControls();
+        // Allow all dropzones incl. empty ones to be accessed.
         self.addAllDroppablesToControls();
 
         self.droppables[0].getElement().focus();
@@ -500,8 +496,7 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
       self.draggables.forEach(draggable => self.setDraggableAriaLabel(draggable));
       self.disableDraggables();
 
-      // Weird to remove and add, but that will ensure tabindex to be correct
-      self.removeAllDroppablesFromControls();
+      // Allow all dropzones incl. empty ones to be accessed.
       self.addAllDroppablesToControls();
 
       self.droppables[0].getElement().focus();

--- a/src/scripts/droppable.js
+++ b/src/scripts/droppable.js
@@ -81,6 +81,11 @@ H5P.TextDroppable = (function ($) {
   Droppable.prototype.showSolution = function () {
     const correct = (this.containedDraggable !== null) && (this.containedDraggable.getAnswerText() === this.text);
     if (!correct) {
+
+      const currentAriaLabel = this.$dropzone.attr('aria-label');
+      const correctAnswer = `${this.params.correctAnswer} ${this.text}`;
+      this.$dropzone.attr('aria-label', `${currentAriaLabel} ${correctAnswer}`);
+
       this.$showSolution.html(this.text);
     }
 


### PR DESCRIPTION
When merged in, will introduce the same focus behavior that was introduced for Multiple Choice in [HFP-3554](https://h5ptechnology.atlassian.net/browse/HFP-3554): For both "Check" and "Show Solution" move the focus to the first answer. When calling showSolutions programatically, e.g. by a parent content type, the focus is not set.

## note
If you encounter that: There's a bug when navigating that is not caused by the pull request, see [HFP-3657](https://h5ptechnology.atlassian.net/browse/HFP-3657).

## background
Currently, the behavior of Drag the Words is inconsistent (similar to Multiple Choice, [HFP-3554](https://h5ptechnology.atlassian.net/browse/HFP-3554)).

When clicking on "Check", the focus will be given to a non-tabbable element above the exercise (the instructions) in order to allow tabbing forward through the given answers.

When clicking on "Show solution", the focus will be set to the retry button (by H5P.Question). The dropzone fields are disabled and non-tabbable, so here the user would need to navigate backwards (not tabbing) in order to learn about the correct solutions. On top, the correct answers are in separate elements.