### PR TITLE
HFP-3797 Fix draggable styling

### DIFF
--- a/src/styles/drag-text.css
+++ b/src/styles/drag-text.css
@@ -137,8 +137,8 @@
 }
 
 .h5p-drag-text [aria-grabbed='true'],
-.h5p-drag-text [aria-grabbed].h5p-drag-dropped:not(.ui-state-disabled):hover,
-.h5p-drag-text [aria-grabbed]:not(.ui-state-disabled):hover {
+.h5p-drag-text [aria-grabbed].h5p-drag-dropped:not(.ui-draggable-disabled):hover,
+.h5p-drag-text [aria-grabbed]:not(.ui-draggable-disabled):hover {
   border: 0.1em solid rgb(212,190,216);
   color: #663366;
   background: #edd6e9;
@@ -157,7 +157,7 @@
   opacity: 0.5;
   box-shadow: 0 0 0.8em rgba(0,0,0,0.5);
 }
-.h5p-drag-text [aria-grabbed].ui-state-disabled {
+.h5p-drag-text [aria-grabbed].ui-draggable-disabled {
   opacity: 1;
 }
 
@@ -219,7 +219,7 @@
   display: block;
 }
 
-.h5p-drag-text [aria-dropeffect].ui-droppable.ui-droppable-disabled.ui-state-disabled{
+.h5p-drag-text [aria-dropeffect].ui-droppable.ui-droppable-disabled.ui-draggable-disabled{
   opacity: 1;
 }
 

--- a/src/styles/drag-text.css
+++ b/src/styles/drag-text.css
@@ -117,7 +117,6 @@
 
 .h5p-drag-text [aria-grabbed] {
   line-height: 1.25;
-  cursor: pointer;
   border-radius: 0.25em;
   padding: 0.1em 0.6em;
   margin: 0.3em;
@@ -134,6 +133,10 @@
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
+}
+
+.h5p-drag-text [aria-grabbed]:not(.ui-draggable-disabled) {
+  cursor: pointer;
 }
 
 .h5p-drag-text [aria-grabbed='true'],

--- a/src/styles/drag-text.css
+++ b/src/styles/drag-text.css
@@ -154,11 +154,7 @@
 }
 
 .h5p-drag-text [aria-grabbed='true'] {
-  opacity: 0.5;
   box-shadow: 0 0 0.8em rgba(0,0,0,0.5);
-}
-.h5p-drag-text [aria-grabbed].ui-draggable-disabled {
-  opacity: 1;
 }
 
 .h5p-drag-text .h5p-drag-dropped.h5p-drag-draggable-correct {


### PR DESCRIPTION
Can’t say how this ever came into being, but the CSS of draggables is off and leads to issues:

- Disabling a draggable added the class ui-state-disabled, but the corresponding CSS classes to style the draggables (or rather unstyle them) were named ui-draggable-disabled (potentially some jQueryUI change). The draggables still reacted to hovering them.
- Disabling a draggable did not stop the cursor from changing.
- When selecting/dragging a draggable, the color contrast was insufficient due to opacity.

__When merged in:__
- When a draggable is disabled, it does not change its style on hovering.
- When a draggable is disabled, then hovering it does not lead to the pointer to change the symbol.
- When a draggable is selected/dragged, the color contrast is sufficient.