### PR TITLE
HFP-3847 Improve draggable handling accessibility

### DIFF
--- a/src/scripts/drag-text.js
+++ b/src/scripts/drag-text.js
@@ -959,10 +959,26 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
       'tabindex': '-1'
     }).appendTo($dropzoneContainer)
       .droppable({
-        tolerance: 'pointer',
+        tolerance: 'touch',
+        over: (event) => {
+          self.droppables.forEach(droppable => {
+            if (droppable.getElement() !== event.target) {
+              droppable.disableDropzone();
+            }
+          });
+        },
+        out: () => {
+          self.droppables.forEach(droppable => {
+            droppable.enableDropzone();
+          });
+        },
         drop: function (event, ui) {
           var draggable = self.getDraggableByElement(ui.draggable[0]);
           var droppable = self.getDroppableByElement(event.target);
+
+          self.droppables.forEach(droppable => {
+            droppable.enableDropzone();
+          });
 
           /**
            * Note that drop will run for all initialized DragText dropzones globally. Even other

--- a/src/scripts/droppable.js
+++ b/src/scripts/droppable.js
@@ -248,6 +248,13 @@ H5P.TextDroppable = (function ($) {
   };
 
   /**
+   * Disable dropzone.
+   */
+  Droppable.prototype.disableDropzone = function () {
+    this.$dropzone.droppable({ disabled: true });
+  };
+
+  /**
    * Removes the short format of draggable when it is outside a dropbox.
    */
   Droppable.prototype.removeShortFormat = function () {


### PR DESCRIPTION
When merged in, will change how hovering a dropzone is detected to improve accessibility.

Currently, a dropzone is considered as being hovered based on the mouse pointer being over the dropzone, not the draggable. This can lead to situations where the draggable is in fact hovering the dropzone, suggesting it can be dropped, but the mouse pointer is not hovering the dropzone, the user releases the mouse button and the draggable is reverted to its original position instead of being dropped to the dropzone. This issue often happens when there's a dropzone on the first line, easily leading the mouse pointer getting set off the original drag position (cmp. e.g. https://h5p.org/node/1289113).

The behavior is changed by changing the jQueryUI `tolerance` option for droppables from `pointer` to `touch` and by disabling dropzones on `over` events and `out` events to prevent multiple dropzones from being highlighted when being hovered by a draggable at the same time.