### PR TITLE
Allow for custom number of Lines to be selected

### DIFF
--- a/semantics.json
+++ b/semantics.json
@@ -290,6 +290,15 @@
     "optional": true,
     "fields": [
       {
+        "name": "numLines",
+        "type": "number",
+        "label": "Number of Lines to use",
+        "description": "Setting this to a number less than the number of paragraphs and greater than 1 will make it randomly select paragraphs each time",
+        "importance": "low",
+        "optional": true,
+        "min": 2
+      },
+      {
         "label": "Enable \"Retry\"",
         "importance": "low",
         "name": "enableRetry",

--- a/src/scripts/drag-text.js
+++ b/src/scripts/drag-text.js
@@ -119,8 +119,8 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
     this.answered = false;
 
     // If NumLines Parameter is properly set this will select a random set of paragraphs from the base textField parameter	  
-    if (!(this.params.behaviour.numLines <= 1 || this.params.behaviour.numLines >= this.params.textField.split('\n\n').length)) {
-      this.params.textField = this.params.textField.split('\n\n').filter((line, index, self) => self.indexOf(line) === index).sort(() => Math.random() - 0.5).slice(0, this.params.behaviour.numLines).join('\n\n')
+    if (!(this.params.behaviour.numLines <= 2 || this.params.behaviour.numLines >= this.params.textField.split('\n\n').length)) {
+      this.params.textField = this.params.textField.split('\n\n').sort(() => Math.random() - 0.5).slice(0, this.params.behaviour.numLines).join('\n\n')
     }
 
     // Convert line breaks to HTML

--- a/src/scripts/drag-text.js
+++ b/src/scripts/drag-text.js
@@ -85,6 +85,7 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
       submitAnswer: "Submit",
       tryAgain: "Retry",
       behaviour: {
+	numLines: null,
         enableRetry: true,
         enableSolutionsButton: true,
         enableCheckButton: true,
@@ -116,6 +117,11 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
 
     // Keeps track of if Question has been answered
     this.answered = false;
+
+    // If NumLines Parameter is properly set this will select a random set of paragraphs from the base textField parameter	  
+    if (!(this.params.behaviour.numLines <= 1 || this.params.behaviour.numLines >= this.params.textField.split('\n\n').length)) {
+      this.params.textField = this.params.textField.split('\n\n').filter((line, index, self) => self.indexOf(line) === index).sort(() => Math.random() - 0.5).slice(0, this.params.behaviour.numLines).join('\n\n')
+    }
 
     // Convert line breaks to HTML
     this.textFieldHtml = this.params.textField.replace(/(\r\n|\n|\r)/gm, "<br/>");


### PR DESCRIPTION
This small patch to the Drag Text content type allows users to select a custom number of paragraphs to be used each time the quiz is taken. It incorporates logic similar to that of the numCardsToUse parameter in the memory game content type. This is very useful for users who have a large block of text they want to convert to drag-text quizzes but who don't want to have to make numerous amounts of quizzes. One thing to note. I noticed that the javascript logic for this content type seems to be taken from "dist/h5p-drag-text.js" rather than "scripts/h5p-drag-text.js", I have a similar patch for "dist/h5p-drag-text.js" as well but I can't figure out where that fits in this repository.