### PR TITLE
HFP-4135 Add tooltip for dropped draggables

### DIFF
--- a/src/scripts/drag-text.js
+++ b/src/scripts/drag-text.js
@@ -226,12 +226,14 @@ H5P.DragText = (function ($, Question, ConfirmationDialog) {
    */
   DragText.prototype.updateDroppableElement = function(event) {
     const dropZone = event.data.target;
-    const draggable = event.data.element;
+    const draggable = this.getDraggableByElement(event.data.element);
     const droppable = this.getDroppableByElement(dropZone);
 
     if (dropZone) {
-      this.setDroppableLabel(dropZone, draggable.textContent, droppable.getIndex());
+      this.setDroppableLabel(dropZone, event.data.element.textContent, droppable.getIndex());
     }
+
+    draggable.setTooltipText(event.type === 'drop' ? draggable.text : '');
   };
 
   /**

--- a/src/scripts/draggable.js
+++ b/src/scripts/draggable.js
@@ -33,6 +33,8 @@ H5P.TextDraggable = (function ($) {
     self.$draggable.on('touchstart', stopPropagation);
     self.$draggable.on('touchmove', stopPropagation);
     self.$draggable.on('touchend', stopPropagation);
+
+    self.tooltip = H5P.Tooltip(self.$draggable.get(0), {position: 'bottom'});
   }
 
   Draggable.prototype = Object.create(H5P.EventDispatcher.prototype);
@@ -221,6 +223,18 @@ H5P.TextDraggable = (function ($) {
    */
   Draggable.prototype.setShortFormat = function () {
     this.$draggable.html(this.shortFormat);
+  };
+
+  /**
+   * Set tooltip text.
+   * @param {string} text Tooltip text.
+   */
+  Draggable.prototype.setTooltipText = function (text) {
+    if (typeof text !== 'string') {
+      return;
+    }
+
+    this.tooltip.setText(text);
   };
 
   /**


### PR DESCRIPTION
When merged in, dropped draggables will receive a tooltip displaying the full draggable text.