### PR TITLE
Fix/va 1194 fix draggable styling

### DIFF
--- a/src/scripts/draggable.js
+++ b/src/scripts/draggable.js
@@ -220,11 +220,17 @@ H5P.TextDraggable = (function ($) {
    * Sets short format of draggable when inside a dropbox.
    */
   Draggable.prototype.setShortFormat = function () {
-    this.$draggable.find('span').html(this.shortFormat);
+    const span = this.$draggable[0].querySelector('span');
 
-    if (this.shortFormat !== this.text) {
-      H5P.Tooltip(this.$draggable[0], { text: this.text });
-    }
+    // On restart, the dropzones are transitioning in width, 300ms required before width is stable
+    const delay = span.clientWidth === 0 ? 300 : 0;
+
+    window.setTimeout(() => {
+      const isOverflowing = span.scrollWidth > span.clientWidth;
+      if (isOverflowing) {
+        this.tooltip = H5P.Tooltip(this.$draggable[0], { text: this.text });
+      }
+    }, delay);
   };
 
   /**
@@ -240,9 +246,7 @@ H5P.TextDraggable = (function ($) {
    * Removes the short format of draggable when it is outside a dropbox.
    */
   Draggable.prototype.removeShortFormat = function () {
-    this.$draggable.find('span').html(this.text);
-
-    this.$draggable.find('.h5p-tooltip').remove();
+    this.tooltip?.remove();
   };
 
   /**

--- a/src/styles/drag-text.css
+++ b/src/styles/drag-text.css
@@ -9,7 +9,7 @@
   display: none;
 }
 
-.h5p-drag-text .h5p-draggable {
+.h5p-drag-text .h5p-draggable:not(.h5p-draggable--dropped) {
   margin: var(--h5p-theme-spacing-xxs);
 }
 

--- a/src/styles/drag-text.css
+++ b/src/styles/drag-text.css
@@ -24,6 +24,11 @@
   white-space: nowrap;
 }
 
+.h5p-drag-text .h5p-draggable.h5p-draggable--has-handle.h5p-draggable-correct,
+.h5p-drag-text .h5p-draggable.h5p-draggable--has-handle.h5p-draggable-wrong {
+  padding-left: var(--handle-width);
+}
+
 .h5p-drag-text .h5p-drag-inner p {
   font-size: var(--h5p-theme-font-size-m);
   font-weight: normal;

--- a/src/styles/drag-text.css
+++ b/src/styles/drag-text.css
@@ -29,6 +29,11 @@
   padding-left: var(--handle-width);
 }
 
+.h5p-drag-text:has(.h5p-draggable-correct) .h5p-drag-draggables-container .h5p-draggable,
+.h5p-drag-text:has(.h5p-draggable-wrong) .h5p-drag-draggables-container .h5p-draggable {
+  padding-left: 0;
+}
+
 .h5p-drag-text .h5p-drag-inner p {
   font-size: var(--h5p-theme-font-size-m);
   font-weight: normal;

--- a/src/styles/drag-text.css
+++ b/src/styles/drag-text.css
@@ -9,8 +9,19 @@
   display: none;
 }
 
+.h5p-drag-text .h5p-draggable.h5p-draggable--dropped {
+  width: calc(100% - var(--handle-width));
+}
+
 .h5p-drag-text .h5p-draggable:not(.h5p-draggable--dropped) {
   margin: var(--h5p-theme-spacing-xxs);
+}
+
+.h5p-drag-text .h5p-draggable.h5p-draggable--dropped span:not(.h5p-hidden-read) {
+  width: calc(100% - 2 * var(--h5p-theme-spacing-xs)); /* var is inline padding of Draggable component */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .h5p-drag-text .h5p-drag-inner p {


### PR DESCRIPTION
When merged in, will
- Remove the now obsolete margin for draggables inside a dropzone,
- Ensure that the draggable's width in a dropzone does not exceed the maximum width (and leave ellipses to CSS), and
- as a bonus fix the tooltip that was not properly removed when removing a draggable from a dropzone.